### PR TITLE
Sometimes scopes maps can be unset. Set defaults.

### DIFF
--- a/src/main/groovy/org/iatoki/gradle/play/idea/PlayIdeaPlugin.groovy
+++ b/src/main/groovy/org/iatoki/gradle/play/idea/PlayIdeaPlugin.groovy
@@ -19,6 +19,10 @@ class PlayIdeaPlugin implements Plugin<Project> {
             outputDir = project.file("${project.buildDir}/playBinary/classes")
             testOutputDir = project.file("${project.buildDir}/playBinary/testClasses")
 
+            scopes.COMPILE = scopes.COMPILE ?: [plus: [], minus: []]
+            scopes.RUNTIME = scopes.RUNTIME ?: [plus: [], minus: []]
+            scopes.TEST = scopes.TEST ?: [plus: [], minus: []]
+            
             scopes.COMPILE.plus += [ project.configurations.play ]
             scopes.RUNTIME.plus += [ project.configurations.playRun ]
             scopes.RUNTIME.minus += [ project.configurations.play ]


### PR DESCRIPTION
The version of the plugin prior to this change causes an error in our build, due to scopes.COMPILE and their companions being null.

This simply gives them a default value if they're null.